### PR TITLE
Fj 2024 lesson 12

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,6 +89,12 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-impl:0.12.6")
     implementation("io.jsonwebtoken:jjwt-jackson:0.12.6")
 
+    // https://mvnrepository.com/artifact/org.springframework.security/spring-security-test
+    testImplementation("org.springframework.security:spring-security-test:6.3.4")
+
+    // https://mvnrepository.com/artifact/org.testcontainers/postgresql
+    testImplementation("org.testcontainers:postgresql:1.20.3")
+
 
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,6 +81,14 @@ dependencies {
     // https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jsr310
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.0")
 
+    // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-security
+    implementation("org.springframework.boot:spring-boot-starter-security:3.3.5")
+
+
+    implementation("io.jsonwebtoken:jjwt-api:0.12.6")
+    implementation("io.jsonwebtoken:jjwt-impl:0.12.6")
+    implementation("io.jsonwebtoken:jjwt-jackson:0.12.6")
+
 
 }
 

--- a/src/main/java/org/example/task12/advice/ExceptionAdvice.java
+++ b/src/main/java/org/example/task12/advice/ExceptionAdvice.java
@@ -1,0 +1,40 @@
+package org.example.task12.advice;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import org.example.task12.security.exceptions.UserAlreadyRegisteredException;
+import org.example.task8.advice.details.ExceptionDetails;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class ExceptionAdvice {
+    @ExceptionHandler(UserAlreadyRegisteredException.class)
+    public ResponseEntity<ExceptionDetails> handleEntityNotFoundException(UserAlreadyRegisteredException ex) {
+        return new ResponseEntity<>(
+                new ExceptionDetails(
+                        HttpStatus.BAD_REQUEST.value(),
+                        ex.getMessage()
+                ), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(UsernameNotFoundException.class)
+    public ResponseEntity<ExceptionDetails> handleEntityNotFoundException(UsernameNotFoundException ex) {
+        return new ResponseEntity<>(
+                new ExceptionDetails(
+                        HttpStatus.NOT_FOUND.value(),
+                        ex.getMessage()
+                ), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(ExpiredJwtException.class)
+    public ResponseEntity<ExceptionDetails> handleEntityNotFoundException(ExpiredJwtException ex) {
+        return new ResponseEntity<>(
+                new ExceptionDetails(
+                        HttpStatus.BAD_REQUEST.value(),
+                        ex.getMessage()
+                ), HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/org/example/task12/config/AuthenticationManagerConfig.java
+++ b/src/main/java/org/example/task12/config/AuthenticationManagerConfig.java
@@ -1,0 +1,15 @@
+package org.example.task12.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+
+@Configuration
+public class AuthenticationManagerConfig {
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+}

--- a/src/main/java/org/example/task12/config/AuthenticationProviderConfig.java
+++ b/src/main/java/org/example/task12/config/AuthenticationProviderConfig.java
@@ -1,0 +1,23 @@
+package org.example.task12.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@RequiredArgsConstructor
+public class AuthenticationProviderConfig {
+    private final PasswordEncoder passwordEncoder;
+    private final UserDetailsService userDetailsService;
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider(passwordEncoder);
+        provider.setUserDetailsService(userDetailsService);
+        return provider;
+    }
+}

--- a/src/main/java/org/example/task12/config/FilterChainConfig.java
+++ b/src/main/java/org/example/task12/config/FilterChainConfig.java
@@ -1,0 +1,51 @@
+package org.example.task12.config;
+
+import lombok.RequiredArgsConstructor;
+import org.example.task12.security.filter.JwtAuthenticationFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class FilterChainConfig {
+    private final JwtAuthenticationFilter jwtAuthFilter;
+    private final AuthenticationProvider authenticationProvider;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(request -> {
+                    var corsConfiguration = new CorsConfiguration();
+                    corsConfiguration.setAllowedOriginPatterns(List.of("*"));
+                    corsConfiguration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+                    corsConfiguration.setAllowedHeaders(List.of("*"));
+                    corsConfiguration.setAllowCredentials(true);
+
+                    return corsConfiguration;
+                }))
+                .authorizeHttpRequests(matcherRegistry ->
+                        matcherRegistry
+                                .requestMatchers(
+                                        "/api/v1/auth/authenticate",
+                                        "/api/v1/auth/register").permitAll()
+                                .anyRequest().authenticated())
+                .sessionManagement(sessionManagementConfigurer ->
+                        sessionManagementConfigurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authenticationProvider(authenticationProvider)
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+}

--- a/src/main/java/org/example/task12/config/PasswordEncoderConfig.java
+++ b/src/main/java/org/example/task12/config/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package org.example.task12.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/org/example/task12/controller/AuthenticationController.java
+++ b/src/main/java/org/example/task12/controller/AuthenticationController.java
@@ -3,10 +3,16 @@ package org.example.task12.controller;
 import lombok.RequiredArgsConstructor;
 import org.example.task12.dto.AuthenticationRequest;
 import org.example.task12.dto.AuthenticationResponse;
+import org.example.task12.dto.ChangePasswordRequest;
 import org.example.task12.dto.RegistrationRequest;
 import org.example.task12.security.service.AuthenticationService;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,5 +28,23 @@ public class AuthenticationController {
     @PostMapping("api/v1/auth/authenticate")
     public AuthenticationResponse authentication(@RequestBody AuthenticationRequest request) {
         return authenticationService.authenticate(request);
+    }
+
+    @PostMapping("api/v1/auth/logout")
+    @ResponseStatus(HttpStatus.OK)
+    public void logout(@RequestHeader("Authorization") String token) {
+        authenticationService.logout(token);
+    }
+
+    @PostMapping("api/v1/auth/change-password")
+    @ResponseStatus(HttpStatus.OK)
+    public void changePassword(@RequestBody ChangePasswordRequest request, @RequestHeader("Authorization") String token) {
+        authenticationService.changePassword(request, token);
+    }
+
+    @GetMapping("api/v1/admin")
+    @PreAuthorize("hasAuthority('ADMIN')")
+    public String admin() {
+        return "Admin endpoint";
     }
 }

--- a/src/main/java/org/example/task12/controller/AuthenticationController.java
+++ b/src/main/java/org/example/task12/controller/AuthenticationController.java
@@ -1,0 +1,26 @@
+package org.example.task12.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.task12.dto.AuthenticationRequest;
+import org.example.task12.dto.AuthenticationResponse;
+import org.example.task12.dto.RegistrationRequest;
+import org.example.task12.security.service.AuthenticationService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthenticationController {
+    private final AuthenticationService authenticationService;
+
+    @PostMapping("api/v1/auth/register")
+    public AuthenticationResponse register(@RequestBody RegistrationRequest request) {
+        return authenticationService.register(request);
+    }
+
+    @PostMapping("api/v1/auth/authenticate")
+    public AuthenticationResponse authentication(@RequestBody AuthenticationRequest request) {
+        return authenticationService.authenticate(request);
+    }
+}

--- a/src/main/java/org/example/task12/dto/AuthenticationRequest.java
+++ b/src/main/java/org/example/task12/dto/AuthenticationRequest.java
@@ -1,7 +1,7 @@
 package org.example.task12.dto;
 
 public record AuthenticationRequest(
-        String login,
+        String username,
         String password,
         boolean rememberMe
 ) {

--- a/src/main/java/org/example/task12/dto/AuthenticationRequest.java
+++ b/src/main/java/org/example/task12/dto/AuthenticationRequest.java
@@ -1,0 +1,8 @@
+package org.example.task12.dto;
+
+public record AuthenticationRequest(
+        String login,
+        String password,
+        boolean rememberMe
+) {
+}

--- a/src/main/java/org/example/task12/dto/AuthenticationResponse.java
+++ b/src/main/java/org/example/task12/dto/AuthenticationResponse.java
@@ -1,0 +1,6 @@
+package org.example.task12.dto;
+
+public record AuthenticationResponse(
+        String token
+) {
+}

--- a/src/main/java/org/example/task12/dto/ChangePasswordRequest.java
+++ b/src/main/java/org/example/task12/dto/ChangePasswordRequest.java
@@ -1,0 +1,6 @@
+package org.example.task12.dto;
+
+public record ChangePasswordRequest(
+        String newPassword
+) {
+}

--- a/src/main/java/org/example/task12/dto/RegistrationRequest.java
+++ b/src/main/java/org/example/task12/dto/RegistrationRequest.java
@@ -1,0 +1,7 @@
+package org.example.task12.dto;
+
+public record RegistrationRequest(
+        String login,
+        String password
+) {
+}

--- a/src/main/java/org/example/task12/dto/RegistrationRequest.java
+++ b/src/main/java/org/example/task12/dto/RegistrationRequest.java
@@ -1,7 +1,7 @@
 package org.example.task12.dto;
 
 public record RegistrationRequest(
-        String login,
+        String username,
         String password
 ) {
 }

--- a/src/main/java/org/example/task12/entity/ApiUser.java
+++ b/src/main/java/org/example/task12/entity/ApiUser.java
@@ -5,6 +5,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -32,6 +34,7 @@ import java.util.List;
 public class ApiUser implements UserDetails {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id", nullable = false)
     private Long id;
 

--- a/src/main/java/org/example/task12/entity/ApiUser.java
+++ b/src/main/java/org/example/task12/entity/ApiUser.java
@@ -1,0 +1,65 @@
+package org.example.task12.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.example.task12.enums.Role;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+
+@Entity
+@Table(name = "api_user")
+public class ApiUser implements UserDetails {
+
+    @Id
+    @Column(name = "user_id", nullable = false)
+    private Long id;
+
+    @Column(name = "login", nullable = false)
+    private String login;
+
+    @Column(name = "hash_password", nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "user_role", nullable = false)
+    private Role role;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private transient List<JwtToken> tokens;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(role.name()));
+    }
+
+    @Override
+    public String getUsername() {
+        return login;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+}

--- a/src/main/java/org/example/task12/entity/JwtToken.java
+++ b/src/main/java/org/example/task12/entity/JwtToken.java
@@ -3,6 +3,8 @@ package org.example.task12.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -24,6 +26,7 @@ import lombok.Setter;
 public class JwtToken {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)
     private Long id;
 

--- a/src/main/java/org/example/task12/entity/JwtToken.java
+++ b/src/main/java/org/example/task12/entity/JwtToken.java
@@ -1,0 +1,39 @@
+package org.example.task12.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+
+@Entity
+@Table(name = "jwt_tokens")
+public class JwtToken {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "token", nullable = false)
+    private String token;
+
+    @Column(name = "revoked", nullable = false)
+    private boolean revoked;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private ApiUser user;
+}

--- a/src/main/java/org/example/task12/enums/Role.java
+++ b/src/main/java/org/example/task12/enums/Role.java
@@ -1,0 +1,6 @@
+package org.example.task12.enums;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/src/main/java/org/example/task12/properties/JwtProperties.java
+++ b/src/main/java/org/example/task12/properties/JwtProperties.java
@@ -1,0 +1,20 @@
+package org.example.task12.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DurationUnit;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+@Component
+@ConfigurationProperties(prefix = "security.jwt")
+@Getter
+@Setter
+public class JwtProperties {
+    private String jwtKey;
+    private @DurationUnit(ChronoUnit.SECONDS) Duration defaultExpiration;
+    private @DurationUnit(ChronoUnit.SECONDS) Duration rememberMeExpiration;
+}

--- a/src/main/java/org/example/task12/security/exceptions/JwtTokenExpiredException.java
+++ b/src/main/java/org/example/task12/security/exceptions/JwtTokenExpiredException.java
@@ -1,0 +1,7 @@
+package org.example.task12.security.exceptions;
+
+public class JwtTokenExpiredException extends RuntimeException {
+    public JwtTokenExpiredException(String tokenExpired) {
+        super(tokenExpired);
+    }
+}

--- a/src/main/java/org/example/task12/security/exceptions/JwtTokenNotFoundException.java
+++ b/src/main/java/org/example/task12/security/exceptions/JwtTokenNotFoundException.java
@@ -1,0 +1,7 @@
+package org.example.task12.security.exceptions;
+
+public class JwtTokenNotFoundException extends RuntimeException {
+    public JwtTokenNotFoundException(String tokenNotFound) {
+        super(tokenNotFound);
+    }
+}

--- a/src/main/java/org/example/task12/security/exceptions/JwtTokenRevokedException.java
+++ b/src/main/java/org/example/task12/security/exceptions/JwtTokenRevokedException.java
@@ -1,0 +1,7 @@
+package org.example.task12.security.exceptions;
+
+public class JwtTokenRevokedException extends RuntimeException {
+    public JwtTokenRevokedException(String tokenRevoked) {
+        super(tokenRevoked);
+    }
+}

--- a/src/main/java/org/example/task12/security/exceptions/JwtUsernameNotFoundException.java
+++ b/src/main/java/org/example/task12/security/exceptions/JwtUsernameNotFoundException.java
@@ -1,0 +1,7 @@
+package org.example.task12.security.exceptions;
+
+public class JwtUsernameNotFoundException extends RuntimeException {
+    public JwtUsernameNotFoundException(String usernameNotFound) {
+        super(usernameNotFound);
+    }
+}

--- a/src/main/java/org/example/task12/security/exceptions/UserAlreadyRegisteredException.java
+++ b/src/main/java/org/example/task12/security/exceptions/UserAlreadyRegisteredException.java
@@ -1,0 +1,7 @@
+package org.example.task12.security.exceptions;
+
+public class UserAlreadyRegisteredException extends RuntimeException {
+    public UserAlreadyRegisteredException(String s) {
+        super(s);
+    }
+}

--- a/src/main/java/org/example/task12/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/task12/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,100 @@
+package org.example.task12.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.net.HttpHeaders;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.task12.entity.ApiUser;
+import org.example.task12.security.exceptions.JwtTokenExpiredException;
+import org.example.task12.security.exceptions.JwtTokenRevokedException;
+import org.example.task12.security.exceptions.JwtUsernameNotFoundException;
+import org.example.task12.security.service.UserService;
+import org.example.task12.security.utils.JwtExtractUtils;
+import org.example.task8.advice.details.ExceptionDetails;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    public static final String BEARER = "Bearer ";
+    private final UserService userService;
+    private final JwtExtractUtils jwtExtractUtils;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+            if (isContainsJwtToken(authorizationHeader)) {
+
+                String jwtToken = authorizationHeader.substring(BEARER.length()).trim();
+
+                String username = jwtExtractUtils.getUserName(jwtToken)
+                        .orElseThrow(() -> new JwtUsernameNotFoundException("Username not found"));
+
+                if (authenticationIsNotPresent()) {
+                    validateJwtToken(jwtToken);
+                    setAuthentication(request, username);
+                }
+            }
+            filterChain.doFilter(request, response);
+
+        } catch (JwtUsernameNotFoundException | JwtTokenExpiredException | JwtTokenRevokedException e) {
+            addExceptionDetailsToResponse(response, e.getMessage());
+        }
+    }
+
+    private void addExceptionDetailsToResponse(HttpServletResponse response, String message) throws IOException {
+        HttpStatus httpStatus = HttpStatus.UNAUTHORIZED;
+        ExceptionDetails exceptionDetails = new ExceptionDetails(httpStatus.value(), message);
+
+        response.setStatus(httpStatus.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write(objectMapper.writeValueAsString(exceptionDetails));
+    }
+
+    private void validateJwtToken(String jwtToken) {
+        if (jwtExtractUtils.isTokenExpired(jwtToken)) {
+            throw new JwtTokenExpiredException("Token expired");
+        }
+        if (jwtExtractUtils.isTokenRevoked(jwtToken)) {
+            throw new JwtTokenRevokedException("Token revoked");
+        }
+    }
+
+    private void setAuthentication(HttpServletRequest request, String username) {
+        SecurityContextHolder.getContext().setAuthentication(createAuthenticationToken(request,
+                userService.loadUserByUsername(username)));
+    }
+
+    private static boolean authenticationIsNotPresent() {
+        return SecurityContextHolder.getContext().getAuthentication() == null;
+    }
+
+    private static boolean isContainsJwtToken(String header) {
+        return header != null && header.startsWith(BEARER);
+    }
+
+    private static UsernamePasswordAuthenticationToken createAuthenticationToken(HttpServletRequest request, ApiUser user) {
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+        token.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+        return token;
+    }
+}

--- a/src/main/java/org/example/task12/security/repository/ApiUserRepository.java
+++ b/src/main/java/org/example/task12/security/repository/ApiUserRepository.java
@@ -1,0 +1,12 @@
+package org.example.task12.security.repository;
+
+import org.example.task12.entity.ApiUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ApiUserRepository extends JpaRepository<ApiUser, Long> {
+    Optional<ApiUser> findByLogin(String login);
+}

--- a/src/main/java/org/example/task12/security/repository/JwtRepository.java
+++ b/src/main/java/org/example/task12/security/repository/JwtRepository.java
@@ -1,9 +1,16 @@
 package org.example.task12.security.repository;
 
+import org.example.task12.entity.ApiUser;
 import org.example.task12.entity.JwtToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface JwtRepository extends JpaRepository<JwtToken, Long> {
+    Optional<JwtToken> findByToken(String token);
+
+    List<JwtToken> findAllByUserAndRevoked(ApiUser user, boolean revoked);
 }

--- a/src/main/java/org/example/task12/security/repository/JwtRepository.java
+++ b/src/main/java/org/example/task12/security/repository/JwtRepository.java
@@ -1,0 +1,9 @@
+package org.example.task12.security.repository;
+
+import org.example.task12.entity.JwtToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JwtRepository extends JpaRepository<JwtToken, Long> {
+}

--- a/src/main/java/org/example/task12/security/service/AuthenticationService.java
+++ b/src/main/java/org/example/task12/security/service/AuthenticationService.java
@@ -3,36 +3,42 @@ package org.example.task12.security.service;
 import lombok.RequiredArgsConstructor;
 import org.example.task12.dto.AuthenticationRequest;
 import org.example.task12.dto.AuthenticationResponse;
+import org.example.task12.dto.ChangePasswordRequest;
 import org.example.task12.dto.RegistrationRequest;
 import org.example.task12.entity.ApiUser;
 import org.example.task12.entity.JwtToken;
 import org.example.task12.enums.Role;
-import org.example.task12.security.exceptions.UserAlreadyRegisteredException;
-import org.example.task12.security.repository.ApiUserRepository;
+import org.example.task12.security.exceptions.JwtTokenNotFoundException;
 import org.example.task12.security.repository.JwtRepository;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static org.example.task12.security.filter.JwtAuthenticationFilter.BEARER;
 
 @Service
 @RequiredArgsConstructor
 public class AuthenticationService {
-    private final ApiUserRepository apiUserRepository;
-    private final JwtRepository jwtRepository;
+    private final UserService userService;
     private final JwtService jwtService;
+    private final JwtRepository jwtRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
 
     public AuthenticationResponse register(RegistrationRequest request) {
 
-        apiUserRepository.findByLogin(request.login())
-                .ifPresent(user -> {
-                    throw new UserAlreadyRegisteredException("User with login " + request.login() + " already exists");
-                });
+        userService.ifUserRegisteredThrowException(request.username());
 
         ApiUser apiUser = ApiUser.builder()
-                .login(request.login())
-                .password(request.password())
+                .login(request.username())
+                .password(passwordEncoder.encode(request.password()))
                 .role(Role.USER)
                 .build();
 
-        apiUserRepository.save(apiUser);
+        userService.save(apiUser);
 
         boolean rememberMe = false;
         String jwtToken = jwtService.generateToken(apiUser, rememberMe);
@@ -44,10 +50,50 @@ public class AuthenticationService {
                 .build());
 
         return new AuthenticationResponse(jwtToken);
-
     }
 
     public AuthenticationResponse authenticate(AuthenticationRequest request) {
-        return null;
+
+        ApiUser apiUser = userService.loadUserByUsername(request.username());
+
+        authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(
+                        request.username(),
+                        request.password()
+                )
+        );
+
+        revokeExistingTokens(apiUser);
+
+        String jwtToken = jwtService.generateToken(apiUser, request.rememberMe());
+
+        jwtRepository.save(JwtToken.builder()
+                .token(jwtToken)
+                .revoked(false)
+                .user(apiUser)
+                .build());
+
+        return new AuthenticationResponse(jwtToken);
+    }
+
+    public void logout(String jwtToken) {
+        jwtToken = jwtToken.replace(BEARER, "").trim();
+        JwtToken token = jwtRepository.findByToken(jwtToken).orElseThrow(() -> new JwtTokenNotFoundException("Token not found"));
+        ApiUser user = token.getUser();
+        revokeExistingTokens(user);
+    }
+
+    public void changePassword(ChangePasswordRequest request, String jwtToken) {
+        jwtToken = jwtToken.replace(BEARER, "").trim();
+        JwtToken token = jwtRepository.findByToken(jwtToken).orElseThrow(() -> new JwtTokenNotFoundException("Token not found"));
+        ApiUser user = token.getUser();
+        user.setPassword(passwordEncoder.encode(request.newPassword()));
+        userService.save(user);
+    }
+
+    private void revokeExistingTokens(ApiUser apiUser) {
+        List<JwtToken> tokens = jwtRepository.findAllByUserAndRevoked(apiUser, false);
+        tokens.forEach(token -> token.setRevoked(true));
+        jwtRepository.saveAll(tokens);
     }
 }

--- a/src/main/java/org/example/task12/security/service/AuthenticationService.java
+++ b/src/main/java/org/example/task12/security/service/AuthenticationService.java
@@ -1,0 +1,53 @@
+package org.example.task12.security.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.task12.dto.AuthenticationRequest;
+import org.example.task12.dto.AuthenticationResponse;
+import org.example.task12.dto.RegistrationRequest;
+import org.example.task12.entity.ApiUser;
+import org.example.task12.entity.JwtToken;
+import org.example.task12.enums.Role;
+import org.example.task12.security.exceptions.UserAlreadyRegisteredException;
+import org.example.task12.security.repository.ApiUserRepository;
+import org.example.task12.security.repository.JwtRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthenticationService {
+    private final ApiUserRepository apiUserRepository;
+    private final JwtRepository jwtRepository;
+    private final JwtService jwtService;
+
+    public AuthenticationResponse register(RegistrationRequest request) {
+
+        apiUserRepository.findByLogin(request.login())
+                .ifPresent(user -> {
+                    throw new UserAlreadyRegisteredException("User with login " + request.login() + " already exists");
+                });
+
+        ApiUser apiUser = ApiUser.builder()
+                .login(request.login())
+                .password(request.password())
+                .role(Role.USER)
+                .build();
+
+        apiUserRepository.save(apiUser);
+
+        boolean rememberMe = false;
+        String jwtToken = jwtService.generateToken(apiUser, rememberMe);
+
+        jwtRepository.save(JwtToken.builder()
+                .token(jwtToken)
+                .revoked(false)
+                .user(apiUser)
+                .build());
+
+        return new AuthenticationResponse(jwtToken);
+
+    }
+
+    public AuthenticationResponse authenticate(AuthenticationRequest request) {
+        return null;
+    }
+}

--- a/src/main/java/org/example/task12/security/service/JwtService.java
+++ b/src/main/java/org/example/task12/security/service/JwtService.java
@@ -1,14 +1,12 @@
 package org.example.task12.security.service;
 
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.io.Decoders;
-import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
 import org.example.task12.entity.ApiUser;
 import org.example.task12.properties.JwtProperties;
+import org.example.task12.security.utils.JwtExtractUtils;
 import org.springframework.stereotype.Service;
 
-import javax.crypto.SecretKey;
 import java.time.Duration;
 import java.util.Date;
 import java.util.HashMap;
@@ -17,6 +15,7 @@ import java.util.HashMap;
 @RequiredArgsConstructor
 public class JwtService {
     private final JwtProperties jwtProperties;
+    private final JwtExtractUtils jwtExtractUtils;
 
     public String generateToken(ApiUser apiUser, boolean rememberMe) {
 
@@ -25,7 +24,7 @@ public class JwtService {
                 .subject(apiUser.getUsername())
                 .issuedAt(getIssuedAt())
                 .expiration(getExpiration(rememberMe))
-                .signWith(getSignInKey(), Jwts.SIG.HS256)
+                .signWith(jwtExtractUtils.getSignInKey(), Jwts.SIG.HS256)
                 .compact();
     }
 
@@ -37,9 +36,5 @@ public class JwtService {
         Duration expirationTime = rememberMe ? jwtProperties.getRememberMeExpiration() : jwtProperties.getDefaultExpiration();
 
         return new Date(System.currentTimeMillis() + expirationTime.toMillis());
-    }
-
-    private SecretKey getSignInKey() {
-        return Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtProperties.getJwtKey()));
     }
 }

--- a/src/main/java/org/example/task12/security/service/JwtService.java
+++ b/src/main/java/org/example/task12/security/service/JwtService.java
@@ -1,0 +1,45 @@
+package org.example.task12.security.service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.example.task12.entity.ApiUser;
+import org.example.task12.properties.JwtProperties;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.time.Duration;
+import java.util.Date;
+import java.util.HashMap;
+
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+    private final JwtProperties jwtProperties;
+
+    public String generateToken(ApiUser apiUser, boolean rememberMe) {
+
+        return Jwts.builder()
+                .claims(new HashMap<>())
+                .subject(apiUser.getUsername())
+                .issuedAt(getIssuedAt())
+                .expiration(getExpiration(rememberMe))
+                .signWith(getSignInKey(), Jwts.SIG.HS256)
+                .compact();
+    }
+
+    private static Date getIssuedAt() {
+        return new Date(System.currentTimeMillis());
+    }
+
+    private Date getExpiration(boolean rememberMe) {
+        Duration expirationTime = rememberMe ? jwtProperties.getRememberMeExpiration() : jwtProperties.getDefaultExpiration();
+
+        return new Date(System.currentTimeMillis() + expirationTime.toMillis());
+    }
+
+    private SecretKey getSignInKey() {
+        return Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtProperties.getJwtKey()));
+    }
+}

--- a/src/main/java/org/example/task12/security/service/UserService.java
+++ b/src/main/java/org/example/task12/security/service/UserService.java
@@ -1,0 +1,31 @@
+package org.example.task12.security.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.task12.entity.ApiUser;
+import org.example.task12.security.exceptions.UserAlreadyRegisteredException;
+import org.example.task12.security.repository.ApiUserRepository;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService implements UserDetailsService {
+    private final ApiUserRepository apiUserRepository;
+
+    public void ifUserRegisteredThrowException(String login) {
+        apiUserRepository.findByLogin(login)
+                .ifPresent(user -> {
+                    throw new UserAlreadyRegisteredException("User with username " + login + " already exists");
+                });
+    }
+
+    public void save(ApiUser user) {
+        apiUserRepository.save(user);
+    }
+
+    @Override
+    public ApiUser loadUserByUsername(String username) throws UsernameNotFoundException {
+        return apiUserRepository.findByLogin(username).orElseThrow(() -> new UsernameNotFoundException("User not found"));
+    }
+}

--- a/src/main/java/org/example/task12/security/utils/JwtExtractUtils.java
+++ b/src/main/java/org/example/task12/security/utils/JwtExtractUtils.java
@@ -1,0 +1,48 @@
+package org.example.task12.security.utils;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.example.task12.properties.JwtProperties;
+import org.example.task12.security.exceptions.JwtTokenNotFoundException;
+import org.example.task12.security.repository.JwtRepository;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class JwtExtractUtils {
+    private final JwtProperties jwtProperties;
+    private final JwtRepository jwtRepository;
+
+    public Optional<String> getUserName(String token) {
+        return Optional.ofNullable(getClaims(token).getSubject());
+    }
+
+    public boolean isTokenExpired(String token) {
+        return getClaims(token).getExpiration().before(new Date());
+    }
+
+    public boolean isTokenRevoked(String token) {
+        return jwtRepository.findByToken(token)
+                .orElseThrow(() -> new JwtTokenNotFoundException("Token not found"))
+                .isRevoked();
+    }
+
+    public SecretKey getSignInKey() {
+        return Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtProperties.getJwtKey()));
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(getSignInKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/org/example/task5/config/DataInitializerConfig.java
+++ b/src/main/java/org/example/task5/config/DataInitializerConfig.java
@@ -2,12 +2,14 @@ package org.example.task5.config;
 
 import lombok.RequiredArgsConstructor;
 import org.example.task11.pattern.command.handler.CommandInvoker;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationStartedEvent;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.EventListener;
 
 @Configuration
 @RequiredArgsConstructor
+@ConditionalOnProperty(value = "data-initialization.enable", havingValue = "true")
 public class DataInitializerConfig {
     private final CommandInvoker commandInvoker;
 

--- a/src/main/java/org/example/task5/initializer/DataInitializer.java
+++ b/src/main/java/org/example/task5/initializer/DataInitializer.java
@@ -12,6 +12,7 @@ import org.example.task5.logtime.annotation.LogExecutionTime;
 import org.example.task5.model.ApiLocation;
 import org.example.task5.model.Category;
 import org.example.task5.repository.InMemoryRepository;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.List;

--- a/src/main/java/org/example/task9/advice/EventExceptionHandler.java
+++ b/src/main/java/org/example/task9/advice/EventExceptionHandler.java
@@ -22,4 +22,3 @@ public class EventExceptionHandler {
                 ), HttpStatus.NOT_FOUND);
     }
 }
-

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -53,3 +53,9 @@ rest:
 data-initialization:
   threads: 2
   period-seconds: 600
+
+security:
+  jwt:
+    jwt-key: ${JWT_KEY:123456789}
+    default-expiration: 600 # 10 minutes in seconds
+    remember-me-expiration: 2592000 # 30 days in seconds

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -53,6 +53,7 @@ rest:
 data-initialization:
   threads: 2
   period-seconds: 600
+  enable: false
 
 security:
   jwt:

--- a/src/main/resources/db/changelog-master.xml
+++ b/src/main/resources/db/changelog-master.xml
@@ -5,4 +5,5 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
     <include file="v.1/changelog.xml" relativeToChangelogFile="true"/>
+    <include file="v.2/changelog.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/v.2/changelog.xml
+++ b/src/main/resources/db/v.2/changelog.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.6.xsd">
+
+    <changeSet id="add-security" author="tssvett">
+        <tagDatabase tag="v.2.0"/>
+    </changeSet>
+
+    <include file="create-table-api-user.sql" relativeToChangelogFile="true"/>
+    <include file="create-table-jwt-tokens.sql" relativeToChangelogFile="true"/>
+</databaseChangeLog>

--- a/src/main/resources/db/v.2/create-table-api-user.sql
+++ b/src/main/resources/db/v.2/create-table-api-user.sql
@@ -1,0 +1,10 @@
+--liquibase formatted sql
+
+--changeset tssvett:create-table-api-user
+
+CREATE TABLE IF NOT EXISTS api_user (
+    user_id BIGSERIAL NOT NULL PRIMARY KEY,
+    login TEXT NOT NULL,
+    hash_password TEXT NOT NULL,
+    user_role TEXT NOT NULL
+);

--- a/src/main/resources/db/v.2/create-table-jwt-tokens.sql
+++ b/src/main/resources/db/v.2/create-table-jwt-tokens.sql
@@ -1,0 +1,11 @@
+--liquibase formatted sql
+
+--changeset tssvett:create-table-jwt-tokens
+
+CREATE TABLE IF NOT EXISTS jwt_tokens (
+    id BIGSERIAL NOT NULL PRIMARY KEY,
+    token TEXT NOT NULL,
+    revoked BOOLEAN NOT NULL,
+    user_id BIGINT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES api_user(user_id) ON delete CASCADE
+);

--- a/src/test/java/org/example/task12/controller/AuthenticationControllerTest.java
+++ b/src/test/java/org/example/task12/controller/AuthenticationControllerTest.java
@@ -1,0 +1,164 @@
+package org.example.task12.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.App;
+import org.example.task12.dto.AuthenticationRequest;
+import org.example.task12.dto.AuthenticationResponse;
+import org.example.task12.dto.ChangePasswordRequest;
+import org.example.task12.dto.RegistrationRequest;
+import org.example.task12.security.exceptions.UserAlreadyRegisteredException;
+import org.example.task12.security.service.AuthenticationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Test class for the {@link AuthenticationController}
+ */
+
+@AutoConfigureMockMvc
+@SpringBootTest(classes = App.class)
+@ActiveProfiles(profiles = "test")
+class AuthenticationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AuthenticationService authenticationService;
+
+    private static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:17");
+
+    private RegistrationRequest registrationRequest;
+
+    private AuthenticationRequest authenticationRequest;
+
+    private AuthenticationResponse response;
+
+    @DynamicPropertySource
+    static void postgresqlProperties(DynamicPropertyRegistry registry) {
+        postgres.start();
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("security.jwt.jwt-key", () -> "eyJhbGciOiJIUzI1NiJ9eyJzdWIiOiJ0c3N2ZXR0c2YiLCJpYXQiOjE" +
+                "3MzA4NzUxMzUsImV4cCI6MTczMDg3NTczNX0pJ3DENx6ND41ARzjvug8rYiKbW4clEipF1aqaNJfq4");
+    }
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        registrationRequest = new RegistrationRequest("testUser", "testPassword");
+        authenticationRequest = new AuthenticationRequest("testUser", "testPassword", true);
+        response = new AuthenticationResponse("mockJwtToken");
+    }
+
+    @Test
+    void testRegister_correctRequest_shouldReturnJwtToken() throws Exception {
+        //Arrange
+        when(authenticationService.register(registrationRequest)).thenReturn(response);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(registrationRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").value(response.token()));
+
+        verify(authenticationService, times(1)).register(any(RegistrationRequest.class));
+    }
+
+    @Test
+    void testRegister_AlreadyExistingUser_shouldReturnError() throws Exception {
+        //Arrange
+        when(authenticationService.register(registrationRequest)).thenThrow(new UserAlreadyRegisteredException("User already exists"));
+
+        // Act & Assert
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(registrationRequest)))
+                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.code").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.message").value("User already exists"));
+
+        verify(authenticationService, times(1)).register(any(RegistrationRequest.class));
+    }
+
+    @Test
+    void testAuthenticate_correctRequest_shouldReturnJwtToken() throws Exception {
+        //Arrange
+        when(authenticationService.authenticate(authenticationRequest)).thenReturn(response);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/v1/auth/authenticate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(authenticationRequest)))
+                .andExpect(status().isOk());
+
+        verify(authenticationService, times(1)).authenticate(any(AuthenticationRequest.class));
+    }
+
+    @Test
+    void testAuthenticate_userNotFound_shouldReturnError() throws Exception {
+        //Arrange
+        when(authenticationService.authenticate(authenticationRequest)).thenThrow(new UsernameNotFoundException("User not found"));
+
+        // Act & Assert
+        mockMvc.perform(post("/api/v1/auth/authenticate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(authenticationRequest)))
+                .andExpect(status().is(HttpStatus.NOT_FOUND.value()))
+                .andExpect(jsonPath("$.code").value(HttpStatus.NOT_FOUND.value()))
+                .andExpect(jsonPath("$.message").value("User not found"));
+
+        verify(authenticationService, times(1)).authenticate(any(AuthenticationRequest.class));
+    }
+
+    @Test
+    void testLogout_notValidToken_shouldForbiddenStatus() throws Exception {
+        //Arrange
+        doNothing().when(authenticationService).logout("errorToken");
+
+        // Act & Assert
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "errorToken"))
+                .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
+    }
+
+    @Test
+    void testChangePassword_notValidToken_shouldForbiddenStatus() throws Exception {
+        //Arrange
+        doNothing().when(authenticationService).changePassword(any(ChangePasswordRequest.class), any(String.class));
+
+        // Act & Assert
+        mockMvc.perform(post("/api/v1/auth/change-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "errorToken"))
+                .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
+    }
+}

--- a/src/test/java/org/example/task12/security/service/AuthenticationServiceTest.java
+++ b/src/test/java/org/example/task12/security/service/AuthenticationServiceTest.java
@@ -1,0 +1,89 @@
+package org.example.task12.security.service;
+
+import org.example.task12.dto.AuthenticationRequest;
+import org.example.task12.dto.AuthenticationResponse;
+import org.example.task12.dto.RegistrationRequest;
+import org.example.task12.security.exceptions.UserAlreadyRegisteredException;
+import org.example.task12.security.repository.JwtRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class AuthenticationServiceTest {
+
+    @InjectMocks
+    private AuthenticationService authService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private JwtRepository jwtRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    private RegistrationRequest registrationRequest;
+
+    private AuthenticationRequest authenticationRequest;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        registrationRequest = new RegistrationRequest("testUser", "testPassword");
+        authenticationRequest = new AuthenticationRequest("testUser", "testPassword", true);
+    }
+
+    @Test
+    void testRegister_Success() {
+        // Arrange
+        when(passwordEncoder.encode(registrationRequest.password())).thenReturn("encodedPassword");
+
+        String jwtToken = "generatedJwtToken";
+        when(jwtService.generateToken(any(), eq(false))).thenReturn(jwtToken);
+
+        // Act
+        AuthenticationResponse response = authService.register(registrationRequest);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(jwtToken, response.token());
+
+        verify(userService).ifUserRegisteredThrowException(registrationRequest.username());
+        verify(passwordEncoder).encode(registrationRequest.password());
+        verify(jwtService).generateToken(any(), eq(false));
+    }
+
+    @Test
+    void testRegister_UserAlreadyExists() {
+        // Arrange
+        doThrow(new UserAlreadyRegisteredException("User already exists"))
+                .when(userService).ifUserRegisteredThrowException(registrationRequest.username());
+
+        // Act & Assert
+        Exception exception = assertThrows(UserAlreadyRegisteredException.class, () -> {
+            authService.register(registrationRequest);
+        });
+
+        assertEquals("User already exists", exception.getMessage());
+
+        verify(userService).ifUserRegisteredThrowException(registrationRequest.username());
+        verifyNoMoreInteractions(passwordEncoder, userService, jwtService, jwtRepository);
+    }
+}


### PR DESCRIPTION
# Документация для проверки

1. Добавил эндпоинт для регистрации, дтошки для них, адвайсы для обработки ошибок. Ручки регистрации и аутентификации не требуют токена в заголовках, а в ответе отдают токен. Ручки логаута и сброса пароля уже требуют токена в заголовках, и результатом(неожиданно) является логаут или сброс пароля.
2. Для него потребовалось создать сервис аутентификации, сервис для генерации JWT, создать таблицы для юзера и токенов.
3. Токены сохраняю для того, чтобы в теории я мог отозвать токен(просто так без бд их отозвать не вышло)
4. Далее добавил фильтры для запросов, чтобы обрабатывать JWT токены. Фильтр дейсвует следующим образом: Первый путь. Если токен есть в заголовке, то мы достаем из него пользователя, и добавляем аутентификацию если ее не было. Второй путь. Если токена нет в заголовке, то делаем doFilter()
5. Добавил секурити конфиг, в него засунул мой фильтр

# Тестирование функционала
Написал интеграционный тест на контроллер. Поднял контекст спринга, поднял постгрес бд в докер контейнере,  замокал сервис аутентификации.
## Тестирование регистрации
 Проверил, корректный случай(возвращает моковый токен), случай с существующим пользователем(возвращает ошибку).
 
 ## Тестирование аутентификации
 Проверил, корректный случай(возвращает моковый токен), случай с ошибочными входными данными(возвращает ошибку)
 
 ## Тестирование логаута
 Проверил, корректный случай(если токена нет, то ошибку кидает)


 ## Тестирование смены пароля
 Проверил, что если jwt токен некорректный, то пароль сбросить не получится.

Тестирование админскоого эндпоинта
Проверил, что пользователь без роли админа действительно не может вызвать админскую ручку
